### PR TITLE
add ARM builds

### DIFF
--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -15,6 +15,7 @@ builds:
       - darwin
     goarch:
       - amd64
+      - arm64
       # - i386  # does anyone care about i386?
     ldflags:
       - -s -w -X main.version={{.Version}} -X main.commit={{.Commit}} -X main.date={{.Date}} -X main.builtBy=goreleaser

--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -15,6 +15,7 @@ builds:
       - darwin
     goarch:
       - amd64
+      - arm
       - arm64
       # - i386  # does anyone care about i386?
     ldflags:


### PR DESCRIPTION
Adds 32 and 64 bit ARM builds.

I found myself managing links on my Raspberry Pi.

- Verified the 32 bit build works on my RPI on `Linux octopi 5.10.103-v7l+ #1529 SMP Tue Mar 8 12:24:00 GMT 2022 armv7l GNU/Linux`. 
- I don't have a 64-bit install to test on.

